### PR TITLE
plot_tempanomaly_hgt_wind.py uses lower-case stormModel so it doesn't find the grib files

### DIFF
--- a/ush/python/atmos/plot_850mb_200mb_vws.py
+++ b/ush/python/atmos/plot_850mb_200mb_vws.py
@@ -33,7 +33,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_azimuth_reflectivity.py
+++ b/ush/python/atmos/plot_azimuth_reflectivity.py
@@ -57,7 +57,7 @@ def main():
     fhour= int(conf['fhhh'][1:])
     
     # Read ATCF track file to find the TC center at certain forecast hour
-    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     trackfile = os.path.join(conf['COMhafs'], atcftrack)
     track=open(trackfile,'r')
     print('ATCF track file',atcftrack)
@@ -109,7 +109,7 @@ def main():
     lonp= np.asarray(lonp)
     
     # Read variables from GRIB2 file
-    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
     grib2file = os.path.join(conf['COMhafs'], fname)
     print(f'grib2file: {grib2file}')
     grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_azimuth_rh_q.py
+++ b/ush/python/atmos/plot_azimuth_rh_q.py
@@ -57,7 +57,7 @@ def main():
     fhour= int(conf['fhhh'][1:])
     
     # Read ATCF track file to find the TC center at certain forecast hour
-    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     trackfile = os.path.join(conf['COMhafs'], atcftrack)
     track=open(trackfile,'r')
     print('ATCF track file',atcftrack)
@@ -105,7 +105,7 @@ def main():
     lonp= np.asarray(lonp)
     
     # Read variables from GRIB2 file
-    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
     grib2file = os.path.join(conf['COMhafs'], fname)
     print(f'grib2file: {grib2file}')
     grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_azimuth_tempanomaly.py
+++ b/ush/python/atmos/plot_azimuth_tempanomaly.py
@@ -57,7 +57,7 @@ def main():
     fhour= int(conf['fhhh'][1:])
     
     # Read ATCF track file to find the TC center at certain forecast hour
-    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     trackfile = os.path.join(conf['COMhafs'], atcftrack)
     track=open(trackfile,'r')
     print('ATCF track file',atcftrack)
@@ -105,7 +105,7 @@ def main():
     lonp= np.asarray(lonp)
     
     # Read variables from GRIB2 file
-    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
     grib2file = os.path.join(conf['COMhafs'], fname)
     print(f'grib2file: {grib2file}')
     grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_azimuth_wind.py
+++ b/ush/python/atmos/plot_azimuth_wind.py
@@ -57,7 +57,7 @@ def main():
     fhour= int(conf['fhhh'][1:])
     
     # Read ATCF track file to find the TC center at certain forecast hour
-    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    atcftrack = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     trackfile = os.path.join(conf['COMhafs'], atcftrack)
     track=open(trackfile,'r')
     print('ATCF track file',atcftrack)
@@ -105,7 +105,7 @@ def main():
     lonp= np.asarray(lonp)
     
     # Read variables from GRIB2 file
-    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
     grib2file = os.path.join(conf['COMhafs'], fname)
     print(f'grib2file: {grib2file}')
     grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_crs_ew_rh_tempanomaly_wind_rvor.py
+++ b/ush/python/atmos/plot_crs_ew_rh_tempanomaly_wind_rvor.py
@@ -34,12 +34,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 #print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_ew_wind.py
+++ b/ush/python/atmos/plot_crs_ew_wind.py
@@ -34,12 +34,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 #print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_sn_reflectivity.py
+++ b/ush/python/atmos/plot_crs_sn_reflectivity.py
@@ -33,12 +33,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_sn_rh_tempanomaly.py
+++ b/ush/python/atmos/plot_crs_sn_rh_tempanomaly.py
@@ -33,12 +33,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_sn_rh_tempanomaly_wind_rvor.py
+++ b/ush/python/atmos/plot_crs_sn_rh_tempanomaly_wind_rvor.py
@@ -34,12 +34,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_sn_wind.py
+++ b/ush/python/atmos/plot_crs_sn_wind.py
@@ -31,12 +31,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_we_reflectivity.py
+++ b/ush/python/atmos/plot_crs_we_reflectivity.py
@@ -31,12 +31,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_we_rh_tempanomaly.py
+++ b/ush/python/atmos/plot_crs_we_rh_tempanomaly.py
@@ -32,12 +32,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_crs_we_wind.py
+++ b/ush/python/atmos/plot_crs_we_wind.py
@@ -31,12 +31,12 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')   
 
-atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'trak.atcfunix'
+atcffname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'trak.atcfunix'
 atcffile = os.path.join(conf['COMhafs'], atcffname)
 print(f'ATCFfile: {atcffile}')
 df = pd.read_csv(atcffile,header=None)

--- a/ush/python/atmos/plot_goes_ir13.py
+++ b/ush/python/atmos/plot_goes_ir13.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_goes_wv9.py
+++ b/ush/python/atmos/plot_goes_wv9.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_heatflux_wind10m.py
+++ b/ush/python/atmos/plot_heatflux_wind10m.py
@@ -33,7 +33,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_helicity_0-3km_3hourly.py
+++ b/ush/python/atmos/plot_helicity_0-3km_3hourly.py
@@ -119,7 +119,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -131,12 +131,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_helicity_2-5km_3hourly.py
+++ b/ush/python/atmos/plot_helicity_2-5km_3hourly.py
@@ -119,7 +119,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -131,12 +131,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_lhtflux_wind10m.py
+++ b/ush/python/atmos/plot_lhtflux_wind10m.py
@@ -33,7 +33,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_maxW_3hourly.py
+++ b/ush/python/atmos/plot_maxW_3hourly.py
@@ -120,7 +120,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -132,12 +132,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_minW_3hourly.py
+++ b/ush/python/atmos/plot_minW_3hourly.py
@@ -119,7 +119,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -131,12 +131,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_mslp_wind10m.py
+++ b/ush/python/atmos/plot_mslp_wind10m.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_precip_mslp_thk.py
+++ b/ush/python/atmos/plot_precip_mslp_thk.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')
@@ -43,7 +43,7 @@ if conf['stormDomain'] == 'parent':
     grb_apcp = grb # extract apcp from domain grid01
 
 if conf['stormDomain'] == 'storm':
-    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'parent'+'.atm.'+conf['fhhh']+'.grb2'
+    fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'parent'+'.atm.'+conf['fhhh']+'.grb2'
     grib2file = os.path.join(conf['COMhafs'], fname)
     print(f'grib2file for accumulated precipitation: {grib2file}')
     grb_apcp = grib2io.open(grib2file,mode='r') # extract apcp from domain grid01

--- a/ush/python/atmos/plot_precip_swath.py
+++ b/ush/python/atmos/plot_precip_swath.py
@@ -121,7 +121,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -134,7 +134,7 @@ print('lat_adeck = ',lat_adeck)
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'parent'+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'parent'+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_precip_swath_3hourly.py
+++ b/ush/python/atmos/plot_precip_swath_3hourly.py
@@ -118,7 +118,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -131,12 +131,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_reflectivity.py
+++ b/ush/python/atmos/plot_reflectivity.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_rh_hgt_wind.py
+++ b/ush/python/atmos/plot_rh_hgt_wind.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_rhmidlev_hgt_wind.py
+++ b/ush/python/atmos/plot_rhmidlev_hgt_wind.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_shtflux_wind10m.py
+++ b/ush/python/atmos/plot_shtflux_wind10m.py
@@ -33,7 +33,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_ssmisf17_mw37ghz.py
+++ b/ush/python/atmos/plot_ssmisf17_mw37ghz.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_ssmisf17_mw91ghz.py
+++ b/ush/python/atmos/plot_ssmisf17_mw91ghz.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.sat.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_streamline_wind.py
+++ b/ush/python/atmos/plot_streamline_wind.py
@@ -33,7 +33,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_t2m_mslp_wind10m.py
+++ b/ush/python/atmos/plot_t2m_mslp_wind10m.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_temp_hgt_wind.py
+++ b/ush/python/atmos/plot_temp_hgt_wind.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_tempanomaly_hgt_wind.py
+++ b/ush/python/atmos/plot_tempanomaly_hgt_wind.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_tsfc_mslp_wind10m.py
+++ b/ush/python/atmos/plot_tsfc_mslp_wind10m.py
@@ -34,7 +34,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_vort_hgt_wind.py
+++ b/ush/python/atmos/plot_vort_hgt_wind.py
@@ -35,7 +35,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2file: {grib2file}')
 grb = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_wave_hs.py
+++ b/ush/python/atmos/plot_wave_hs.py
@@ -67,7 +67,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -77,7 +77,7 @@ fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'ww3.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'ww3.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2 file: {grib2file}')
 

--- a/ush/python/atmos/plot_wave_tm.py
+++ b/ush/python/atmos/plot_wave_tm.py
@@ -68,7 +68,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -78,7 +78,7 @@ fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'ww3.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'ww3.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname) 
 print(f'grib2 file: {grib2file}')
 

--- a/ush/python/atmos/plot_wave_tp.py
+++ b/ush/python/atmos/plot_wave_tp.py
@@ -68,7 +68,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -78,7 +78,7 @@ fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+'ww3.grb2'
+fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+'ww3.grb2'
 grib2file = os.path.join(conf['COMhafs'], fname)
 print(f'grib2 file: {grib2file}')
 

--- a/ush/python/atmos/plot_wind_swath.py
+++ b/ush/python/atmos/plot_wind_swath.py
@@ -121,7 +121,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -134,12 +134,12 @@ print('lat_adeck = ',lat_adeck)
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/atmos/plot_wind_swath_3hourly.py
+++ b/ush/python/atmos/plot_wind_swath_3hourly.py
@@ -118,7 +118,7 @@ conf['initTime'] = pd.to_datetime(conf['ymdh'], format='%Y%m%d%H', errors='coerc
 
 #===================================================================================================
 # Get lat and lon from adeck file
-adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
 adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
 fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -131,12 +131,12 @@ if len(fhour) < 43:
 cartopy.config['data_dir'] = conf['cartopyDataDir']
 print(conf)
 
-fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.swath.'+'grb2'
+fnameswath = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.swath.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnameswath)
 print(f'grib2file: {grib2file}')
 grbswath = grib2io.open(grib2file,mode='r')
 
-fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
+fnamef00 = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.f000.'+'grb2'
 grib2file = os.path.join(conf['COMhafs'], fnamef00)
 print(f'grib2file: {grib2file}')
 grbf00 = grib2io.open(grib2file,mode='r')

--- a/ush/python/ocean/plot_mld.py
+++ b/ush/python/ocean/plot_mld.py
@@ -70,7 +70,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -86,10 +86,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname)
 nc = xr.open_dataset(ncfile)

--- a/ush/python/ocean/plot_ohc.py
+++ b/ush/python/ocean/plot_ohc.py
@@ -91,7 +91,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -107,10 +107,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname)
 nc = xr.open_dataset(ncfile)

--- a/ush/python/ocean/plot_sss.py
+++ b/ush/python/ocean/plot_sss.py
@@ -70,7 +70,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -86,10 +86,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname)
 nc = xr.open_dataset(ncfile)

--- a/ush/python/ocean/plot_sst.py
+++ b/ush/python/ocean/plot_sst.py
@@ -70,7 +70,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -86,10 +86,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname) 
 nc = xr.open_dataset(ncfile)

--- a/ush/python/ocean/plot_storm_crs_sn_temp.py
+++ b/ush/python/ocean/plot_storm_crs_sn_temp.py
@@ -73,7 +73,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_crs_trk_temp.py
+++ b/ush/python/ocean/plot_storm_crs_trk_temp.py
@@ -73,7 +73,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -88,12 +88,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_crs_we_temp.py
+++ b/ush/python/ocean/plot_storm_crs_we_temp.py
@@ -73,7 +73,7 @@ conf['validTime'] = conf['initTime'] + conf['fcstTime']
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_mld.py
+++ b/ush/python/ocean/plot_storm_mld.py
@@ -72,7 +72,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -88,12 +88,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc' 
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc' 
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.f000'+'.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.f000'+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000) 
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_ohc.py
+++ b/ush/python/ocean/plot_storm_ohc.py
@@ -93,7 +93,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -109,12 +109,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.f000'+'.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.f000'+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_sss.py
+++ b/ush/python/ocean/plot_storm_sss.py
@@ -73,7 +73,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_sst.py
+++ b/ush/python/ocean/plot_storm_sst.py
@@ -73,7 +73,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc' 
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc' 
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc' 
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc' 
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_tempz100m.py
+++ b/ush/python/ocean/plot_storm_tempz100m.py
@@ -73,7 +73,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_tempz40m.py
+++ b/ush/python/ocean/plot_storm_tempz40m.py
@@ -73,7 +73,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_tempz70m.py
+++ b/ush/python/ocean/plot_storm_tempz70m.py
@@ -73,7 +73,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -89,12 +89,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_wvelz100m.py
+++ b/ush/python/ocean/plot_storm_wvelz100m.py
@@ -72,7 +72,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -88,12 +88,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_wvelz40m.py
+++ b/ush/python/ocean/plot_storm_wvelz40m.py
@@ -72,7 +72,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -88,12 +88,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_wvelz70m.py
+++ b/ush/python/ocean/plot_storm_wvelz70m.py
@@ -72,7 +72,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -88,12 +88,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_z20.py
+++ b/ush/python/ocean/plot_storm_z20.py
@@ -86,7 +86,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -102,12 +102,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.f000'+'.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.f000'+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_storm_z26.py
+++ b/ush/python/ocean/plot_storm_z26.py
@@ -86,7 +86,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -102,12 +102,12 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+'f000.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+'f000.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.f000'+'.nc'
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname000 =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.f000'+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile000 = os.path.join(conf['COMhafs'], fname000)
 nc000 = xr.open_dataset(ncfile000)

--- a/ush/python/ocean/plot_z20.py
+++ b/ush/python/ocean/plot_z20.py
@@ -84,7 +84,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -100,10 +100,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname)
 nc = xr.open_dataset(ncfile)

--- a/ush/python/ocean/plot_z26.py
+++ b/ush/python/ocean/plot_z26.py
@@ -84,7 +84,7 @@ print(conf)
 # Get lat and lon from adeck file
 
 if conf['trackon']=='yes':
-    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.trak.atcfunix'
+    adeck_name = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.trak.atcfunix'
     adeck_file = os.path.join(conf['COMhafs'],adeck_name)
 
     fhour,lat_adeck,lon_adeck,init_time,valid_time = get_adeck_track(adeck_file)
@@ -100,10 +100,10 @@ oceanf = glob.glob(os.path.join(conf['COMhafs'],'*f006.nc'))[0].split('/')[-1].s
 ocean = [f for f in oceanf if f == 'hycom' or f == 'mom6'][0]
 
 if ocean == 'mom6':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.mom6.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.mom6.'+conf['fhhh']+'.nc'
 
 if ocean == 'hycom':
-    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.hycom.3z.'+conf['fhhh']+'.nc'
+    fname =  conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.hycom.3z.'+conf['fhhh']+'.nc'
 
 ncfile = os.path.join(conf['COMhafs'], fname)
 nc = xr.open_dataset(ncfile)


### PR DESCRIPTION
- Fixes #15 

This code causes the plot_tempanomaly_hgt_wind.py to produce the wrong GRIB2 filename. For example, instead of HFSA it gets hfsa:

```python
fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].lower()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
```

It should use upper-case stormModel instead:

```python
fname = conf['stormID'].lower()+'.'+conf['ymdh']+'.'+conf['stormModel'].upper()+'.'+conf['stormDomain']+'.atm.'+conf['fhhh']+'.grb2'
```

The stormModel coming from the calling scripts should be correct already. It may be best not to change the case. If you prefer that, removing the ".lower()" or ".upper()" will do it.